### PR TITLE
Added error message if escapeString fails

### DIFF
--- a/fdf.js
+++ b/fdf.js
@@ -48,19 +48,24 @@ exports.createFdf = function (data) {
     var body = new Buffer([]);
 
     _.mapKeys(data, function (value, name) {
-        body = Buffer.concat([
-            body,
-            new Buffer(
-                "<<\n" +
-                "/T (" +
-                escapeString(name) +
-                ")\n" +
-                "/V (" +
-                escapeString(value) +
-                ")\n" +
-                ">>\n"
-            )
-        ]);
+        try {
+            body = Buffer.concat([
+                body,
+                new Buffer(
+                    "<<\n" +
+                    "/T (" +
+                    escapeString(name) +
+                    ")\n" +
+                    "/V (" +
+                    escapeString(value) +
+                    ")\n" +
+                    ">>\n"
+                )
+            ]);
+        } catch (err) {
+            let errMsg = "Cannot escape string: '" + name + ": " + value + "'.";
+            throw Error(errMsg);
+        }
     });
 
     return Buffer.concat([header, body, footer]);


### PR DESCRIPTION
Wrapped buffer in a try catch block, if the escapeString function fails it will output an error message stating the name and value it failed on.
Previously a generic cannot convert null/undefined to string error would be thrown, when passing many values to pdffiller-stream this became difficult to debug.